### PR TITLE
Update to standard `name` attribute for bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ngDatepicker",
+  "name": "ng-datepicker",
   "version": "0.0.1",
   "homepage": "https://github.com/jkuri/ngDatepicker",
   "authors": [


### PR DESCRIPTION
`bower ngDatepicker#*      invalid-meta The "name" is recommended to be lowercase, can contain digits, dots, dashes`

warning should go once this PR merges.